### PR TITLE
added two mplayer-mode functions + minor source tweaks

### DIFF
--- a/mplayer-mode.el
+++ b/mplayer-mode.el
@@ -101,7 +101,7 @@ can be an integer or a string."
   "Entry point to this mode.  Starts playing the file using
 mplayer, and enables some keybindings to support it; see the
 documentation for `mplayer-mode' for available bindings."
-  (interactive "fOpen movie file: ")
+  (interactive "fOpen recording file: ")
   (set (make-local-variable 'mplayer--osd-enabled) nil)
   (set (make-local-variable 'mplayer-process-buffer) (generate-new-buffer "*mplayer*"))
   (set (make-local-variable 'mplayer-process)
@@ -112,12 +112,12 @@ documentation for `mplayer-mode' for available bindings."
   (mplayer-mode t))
 
 (defun mplayer-toggle-pause ()
-  "Pause or play the currently-open movie."
+  "Pause or play the currently-open recording."
   (interactive)
   (mplayer--send "pause"))
 
 (defun mplayer-seek-forward (seconds)
-  "Skip forward in the movie.  By default this is
+  "Skip forward in the recording.  By default this is
 `mplayer-default-seek-step' seconds; it can also be specified as
 a numeric prefix arg, or plain prefix args act as a
 successive (linear) multipliers of `mplayer-default-seek-step'."
@@ -126,7 +126,7 @@ successive (linear) multipliers of `mplayer-default-seek-step'."
     (mplayer--send (format "seek %d 0" seconds))))
 
 (defun mplayer-seek-backward (seconds)
-  "Skip backward in the movie.  By default this is
+  "Skip backward in the recording.  By default this is
 `mplayer-default-seek-step' seconds; it can also be specified as
 a numeric prefix arg, or plain prefix args act as a
 successive (linear) multipliers of `mplayer-default-seek-step'."
@@ -144,7 +144,7 @@ for the type of display."
   (setq mplayer--osd-enabled (not mplayer--osd-enabled)))
 
 (defun mplayer-insert-timestamp ()
-  "Insert a time-stamp of the current movie position in the
+  "Insert a time-stamp of the current recording position in the
 buffer.  See `mplayer-timestamp-format' for the insertion
 format."
   (interactive)


### PR DESCRIPTION
- added functions mplayer-insert-position ("Insert the current recording position in seconds, into the buffer") and mplayer-seek-position ("Seek to some place in the recording.")
- I also replaced all occurrences the string "movie" with "recording". Many transcriptions are audio-based. (Mine mostly are). Mplayer handles audio much the same :-)
- I found some "space-related" changes in the diff. These do not seem to matter much - if at all.
