### PR TITLE
summary on one line

### DIFF
--- a/mplayer-mode.el
+++ b/mplayer-mode.el
@@ -1,5 +1,4 @@
-;;; mplayer-mode.el --- GNU Emacs mode to control mplayer, mainly
-;;; to facilitate transcription and note-taking.
+;;; mplayer-mode.el --- control mplayer, facilitating transcription and note-taking.
 
 ;; Copyright (C) 2011 Mark Hepburn
 


### PR DESCRIPTION
I should have corrected this in my original pull request.

Anyways the extraction tools only see the first line of the summary. You can add an additional line for people reading the source but the first line should be complete on it's own.
